### PR TITLE
Replace autodiscovery queue with autodiscovery job

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,9 @@ Saving the new translation **will not immediately reflect in your application**.
 ![CleanShot 2024-09-19 at 15 15 30](https://github.com/user-attachments/assets/51a9b582-b35e-4df4-a79b-1e0f238715a0)
 
 
-### Configuring a base controller
+### Configuration
+
+#### Configuring a base controller
 
 By default, Rosetta inherits from `ActionController::Base`. If you want to restrict access to the Rosetta interface, you can make Rosetta inherit from your own base controller, by configuring it in the initializer:
 
@@ -163,9 +165,21 @@ end
 
 **Note**: The class name needs to be a string.
 
-### I18n Support 
+#### Setting up the queue for the Autodiscovery Job
 
-As of now, Rosetta does not integrate with the `i18n` gem as a custom backend. It might be done in the future, however it's been decided to build Rosetta independently for now. You still need to use `i18n` for backwards compatibility of your existing translations, localization, as well as the translations of gems that depend on it. 
+Rosetta uses a background job to automatically discover new translations in your codebase. It enqueues jobs in the queue set by default. To configure it to target another queue:
+
+```ruby
+# config/initializers/rosetta.rb
+
+Rosetta.configure do |config|
+  config.queues[:autodiscovery] = "low_priority"
+end
+```
+
+### I18n Support
+
+As of now, Rosetta does not integrate with the `i18n` gem as a custom backend. It might be done in the future, however it's been decided to build Rosetta independently for now. You still need to use `i18n` for backwards compatibility of your existing translations, localization, as well as the translations of gems that depend on it.
 
 ## License
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/app/jobs/rosetta/autodiscovery_job.rb
+++ b/app/jobs/rosetta/autodiscovery_job.rb
@@ -1,0 +1,11 @@
+module Rosetta
+  class AutodiscoveryJob < Rosetta::ApplicationJob
+    queue_as :default
+
+    discard_on ActiveRecord::RecordNotUnique
+
+    def perform(value)
+      TranslationKey.create!(value: value)
+    end
+  end
+end

--- a/app/jobs/rosetta/autodiscovery_job.rb
+++ b/app/jobs/rosetta/autodiscovery_job.rb
@@ -1,6 +1,6 @@
 module Rosetta
   class AutodiscoveryJob < Rosetta::ApplicationJob
-    queue_as :default
+    queue_as { Rosetta.config.queues[:autodiscovery] }
 
     discard_on ActiveRecord::RecordNotUnique
 

--- a/app/models/rosetta/translation_key.rb
+++ b/app/models/rosetta/translation_key.rb
@@ -3,5 +3,9 @@ module Rosetta
     has_many :translations, dependent: :destroy
     # Note: Learn about the design decisions behind this: https://github.com/virolea/rosetta/issues/3
     has_one :translation_in_current_locale, -> { where(locale_id: Rosetta.locale.id) }, class_name: "Translation", dependent: :destroy
+
+    def self.create_later(value)
+      AutodiscoveryJob.perform_later(value)
+    end
   end
 end

--- a/lib/rosetta/configuration.rb
+++ b/lib/rosetta/configuration.rb
@@ -2,12 +2,14 @@ module Rosetta
   class Configuration
     attr_reader :default_locale
     attr_accessor :parent_controller_class
+    attr_accessor :queues
 
     DefaultLocale = Struct.new(:name, :code)
 
     def initialize
       set_default_locale(name: "English", code: "en")
       @parent_controller_class = "ActionController::Base"
+      @queues = {}
     end
 
     def set_default_locale(name:, code:)

--- a/test/jobs/rosetta/autodiscovery_job_test.rb
+++ b/test/jobs/rosetta/autodiscovery_job_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+module Rosetta
+  class AutodiscoveryJobTest < ActiveJob::TestCase
+    test "creates a new key" do
+      assert_difference "Rosetta::TranslationKey.count", 1 do
+        Rosetta::AutodiscoveryJob.perform_now("Test creation from job")
+      end
+    end
+
+    test "ignores duplicate keys" do
+      TranslationKey.create(value: "duplicate")
+
+      perform_enqueued_jobs do
+        assert_nothing_raised do
+          Rosetta::AutodiscoveryJob.perform_later("duplicate")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR updates the former key syncing mechanism with a job-based one. 

This improves the reliability of the code ands remove a layer of complexity in favour of a well known abstraction when it comes to performing code in a separate thread/process.