### PR TITLE
Scope translations to locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![CI](https://github.com/virolea/rosetta/actions/workflows/ci.yml/badge.svg)](https://github.com/virolea/rosetta/actions/workflows/ci.yml)
+
 # Rosetta
 
 Rosetta is a Rails engine proviving a full-fledged internationalization (i18n) solution for your Rails application. It is designed with the following principles in mind:

--- a/app/controllers/concerns/rosetta/locale_scoped.rb
+++ b/app/controllers/concerns/rosetta/locale_scoped.rb
@@ -3,14 +3,13 @@ module Rosetta
     extend ActiveSupport::Concern
 
     included do
-      around_action :set_locale
+      before_action :set_locale
     end
 
     private
 
     def set_locale(&action)
       @locale = Locale.find(params[:locale_id])
-      Rosetta.with_locale(@locale, &action)
     end
   end
 end

--- a/app/controllers/rosetta/locales/translations/missing_controller.rb
+++ b/app/controllers/rosetta/locales/translations/missing_controller.rb
@@ -3,7 +3,7 @@ module Rosetta
     private
 
     def scope
-      super.where.missing(:translation_in_current_locale)
+      TranslationKey.with_missing_translation(@locale)
     end
   end
 end

--- a/app/controllers/rosetta/locales/translations_controller.rb
+++ b/app/controllers/rosetta/locales/translations_controller.rb
@@ -11,7 +11,7 @@ module Rosetta
     private
 
     def scope
-      TranslationKey.includes(:translation_in_current_locale)
+      TranslationKey.with_translation(@locale)
     end
   end
 end

--- a/app/controllers/rosetta/translations_controller.rb
+++ b/app/controllers/rosetta/translations_controller.rb
@@ -3,17 +3,12 @@ module Rosetta
     include LocaleScoped
 
     before_action :set_translation_key
-    before_action :set_translation
 
     def edit
     end
 
     def update
-      if translation_params[:value].blank?
-        @translation_key.public_send(:"#{@locale.code}_translation=", nil)
-      else
-        @translation.update(translation_params)
-      end
+      @translation_key.update(translation_key_params)
 
       render partial: "rosetta/locales/translations/translation_key", locals: { translation_key: @translation_key }
     end
@@ -24,13 +19,8 @@ module Rosetta
       @translation_key = TranslationKey.find(params[:translation_key_id])
     end
 
-    def set_translation
-      @translation = @translation_key.public_send(:"#{@locale.code}_translation") ||
-        @translation_key.public_send(:"build_#{@locale.code}_translation")
-    end
-
-    def translation_params
-      params.require(:translation).permit(:value)
+    def translation_key_params
+      params.require(:translation_key).permit(:"value_#{@locale.code}")
     end
   end
 end

--- a/app/controllers/rosetta/translations_controller.rb
+++ b/app/controllers/rosetta/translations_controller.rb
@@ -10,7 +10,7 @@ module Rosetta
 
     def update
       if translation_params[:value].blank?
-        @translation_key.translation_in_current_locale = nil
+        @translation_key.public_send(:"#{@locale.code}_translation=", nil)
       else
         @translation.update(translation_params)
       end
@@ -25,7 +25,8 @@ module Rosetta
     end
 
     def set_translation
-      @translation = @translation_key.translation_in_current_locale || @translation_key.build_translation_in_current_locale
+      @translation = @translation_key.public_send(:"#{@locale.code}_translation") ||
+        @translation_key.public_send(:"build_#{@locale.code}_translation")
     end
 
     def translation_params

--- a/app/models/rosetta/translation_key.rb
+++ b/app/models/rosetta/translation_key.rb
@@ -1,8 +1,8 @@
 module Rosetta
   class TranslationKey < ApplicationRecord
-    has_many :translations, dependent: :destroy
-    # Note: Learn about the design decisions behind this: https://github.com/virolea/rosetta/issues/3
-    has_one :translation_in_current_locale, -> { where(locale_id: Rosetta.locale.id) }, class_name: "Translation", dependent: :destroy
+    include Translated
+
+    translated_in_all_locales
 
     def self.create_later(value)
       AutodiscoveryJob.perform_later(value)

--- a/app/views/rosetta/locales/translations/_navigation.html.erb
+++ b/app/views/rosetta/locales/translations/_navigation.html.erb
@@ -6,7 +6,7 @@
       <%= tab_link_to locale_translations_missing_index_path(@locale) do %>
         Missing
         <span class="ml-3 hidden md:inline-block rounded-full px-2.5 py-0.5 text-xs font-medium bg-gray-100 text-gray-900 group-[.active]:bg-indigo-100 group-[.active]:text-indigo-600">
-          <%= Rosetta::TranslationKey.where.missing(:translation_in_current_locale).size %>
+          <%= Rosetta::TranslationKey.with_missing_translation(@locale).size %>
         </span>
       <% end %>
     </nav>

--- a/app/views/rosetta/locales/translations/_translation_key.html.erb
+++ b/app/views/rosetta/locales/translations/_translation_key.html.erb
@@ -4,7 +4,7 @@
   </td>
   <td class="px-3 py-4 text-sm text-gray-900 group relative">
     <%= turbo_frame_tag dom_id(translation_key) do %>
-      <%= translation_key.translation_in_current_locale&.value %>
+      <%= translation_key.public_send("#{@locale.code}_translation")&.value %>
 
       <div class="hidden group-hover:flex absolute w-full h-full top-0 left-0 bg-indigo-50 bg-opacity-50 pr-4  items-center justify-end">
         <%= link_to "edit", edit_translation_key_translation_path(translation_key, locale_id: @locale.id), class: "text-indigo-600 hover:text-indigo-900 font-medium" %>

--- a/app/views/rosetta/translations/edit.html.erb
+++ b/app/views/rosetta/translations/edit.html.erb
@@ -1,10 +1,10 @@
 <%= turbo_frame_tag dom_id(@translation_key) do %>
-  <%= form_with model: @translation, url: translation_key_translation_path(@translation_key), method: :patch, class: "relative" do |f| %>
+  <%= form_with model: @translation_key, url: translation_key_translation_path(@translation_key), method: :patch, class: "relative" do |f| %>
     <%= hidden_field_tag :locale_id, @locale.id %>
 
     <div class="overflow-hidden rounded-lg shadow-sm ring-1 ring-inset ring-gray-300 focus-within:ring-2 focus-within:ring-indigo-600">
-      <%= f.label :value, "Translation", class: "sr-only" %>
-      <%= f.text_area :value, row: 3, autofocus: true, placeholder: "Enter your translation", class: "block w-full resize-none border-0 bg-transparent py-1.5 text-gray-900 placeholder:text-gray-400 focus:ring-0 sm:text-sm sm:leading-6" %>
+      <%= f.label :"value_#{@locale.code}", "Translation", class: "sr-only" %>
+      <%= f.text_area :"value_#{@locale.code}", row: 3, autofocus: true, placeholder: "Enter your translation", class: "block w-full resize-none border-0 bg-transparent py-1.5 text-gray-900 placeholder:text-gray-400 focus:ring-0 sm:text-sm sm:leading-6" %>
 
       <div class="py-2" aria-hidden="true">
         <div class="py-px">

--- a/lib/rosetta-rails.rb
+++ b/lib/rosetta-rails.rb
@@ -6,6 +6,8 @@ require "rosetta/store"
 require "rosetta/configuration"
 
 require "rosetta/translated"
+require "rosetta/translated/create"
+require "rosetta/translated/delete"
 
 module Rosetta
   module Base

--- a/lib/rosetta-rails.rb
+++ b/lib/rosetta-rails.rb
@@ -5,6 +5,8 @@ require "rosetta/locale_session"
 require "rosetta/store"
 require "rosetta/configuration"
 
+require "rosetta/translated"
+
 module Rosetta
   module Base
     def locale

--- a/lib/rosetta/store.rb
+++ b/lib/rosetta/store.rb
@@ -46,9 +46,9 @@ module Rosetta
     def load_translations
       loaded_translations = Rosetta.with_locale(@locale) do
         TranslationKey
-          .includes(:translation_in_current_locale)
+          .with_translation(@locale)
           .map do |translation_key|
-          [ translation_key.value, translation_key.translation_in_current_locale&.value ]
+          [ translation_key.value, translation_key.public_send(:"#{@locale.code}_translation")&.value ]
         end.to_h
       end
 

--- a/lib/rosetta/translated.rb
+++ b/lib/rosetta/translated.rb
@@ -11,6 +11,8 @@ module Rosetta
         Locale.all.each do |locale|
           translated_in(locale)
         end
+
+        Locale.register_class_for_translation(self)
       end
 
       def translated_in(locale)

--- a/lib/rosetta/translated.rb
+++ b/lib/rosetta/translated.rb
@@ -1,0 +1,28 @@
+module Rosetta
+  module Translated
+    extend ActiveSupport::Concern
+
+    included do
+      has_many :translations, dependent: :destroy
+    end
+
+    class_methods do
+      def translated_in_all_locales
+        Locale.all.each do |locale|
+          translated_in(locale)
+        end
+      end
+
+      def translated_in(locale)
+        has_one :"#{locale.code}_translation", -> { where(locale_id: locale.id) }, class_name: "Translation", dependent: :destroy
+
+        scope :with_translation, ->(locale) { includes(:"#{locale.code}_translation") }
+        scope :with_missing_translation, ->(locale) { with_translation(locale).where.missing(:"#{locale.code}_translation") }
+      end
+    end
+
+    def translation_in(locale)
+      public_send(:"#{locale.code}_translation")
+    end
+  end
+end

--- a/lib/rosetta/translated/create.rb
+++ b/lib/rosetta/translated/create.rb
@@ -1,0 +1,20 @@
+module Rosetta
+  class Translated::Create
+    attr_reader :value
+
+    def initialize(record, locale, value)
+      @record = record
+      @locale = locale
+      @value = value
+    end
+
+    def save
+      translation.value = @value
+      @record.public_send(:"#{@locale.code}_translation=", translation)
+    end
+
+    def translation
+      @translation ||= @record.public_send(:"build_#{@locale.code}_translation")
+    end
+  end
+end

--- a/lib/rosetta/translated/delete.rb
+++ b/lib/rosetta/translated/delete.rb
@@ -1,0 +1,15 @@
+module Rosetta
+  class Translated::Delete
+    attr_reader :value
+
+    def initialize(record, locale)
+      @record = record
+      @locale = locale
+      @value = nil
+    end
+
+    def save
+      @record.public_send(:"#{@locale.code}_translation=", nil)
+    end
+  end
+end

--- a/test/controllers/rosetta/translations_controller_test.rb
+++ b/test/controllers/rosetta/translations_controller_test.rb
@@ -16,7 +16,7 @@ module Rosetta
 
     test "add a new translation" do
       assert_difference("Translation.count", 1) do
-        patch translation_key_translation_path(@key), params: { locale_id: @locale.id, translation: { value: "Au revoir" } }
+        patch translation_key_translation_path(@key), params: { locale_id: @locale.id, translation_key: { value_fr: "Au revoir" } }
       end
 
       assert_equal "Au revoir", Translation.last.value
@@ -28,7 +28,7 @@ module Rosetta
       Translation.create!(locale: @locale, translation_key: @key, value: "Salut")
 
       assert_no_difference("Translation.count") do
-        patch translation_key_translation_path(@key), params: { locale_id: @locale.id, translation: { value: "Bonjour" } }
+        patch translation_key_translation_path(@key), params: { locale_id: @locale.id, translation_key: { value_fr: "Bonjour" } }
       end
 
       assert_equal "Bonjour", Translation.last.value
@@ -40,7 +40,7 @@ module Rosetta
       Translation.create!(locale: @locale, translation_key: @key, value: "Salut")
 
       assert_difference("Translation.count", -1) do
-        patch translation_key_translation_path(@key), params: { locale_id: @locale.id, translation: { value: "" } }
+        patch translation_key_translation_path(@key), params: { locale_id: @locale.id, translation_key: { value_fr: "" } }
       end
 
       assert_response :success

--- a/test/integration/translations_test.rb
+++ b/test/integration/translations_test.rb
@@ -25,7 +25,7 @@ class TranslationsTest < ActionDispatch::IntegrationTest
     key = Rosetta::TranslationKey.create(value: "Available locales")
 
     # Create the translation
-    patch rosetta.translation_key_translation_path(key), params: { locale_id: locale.id, translation: { value: "Langues disponibles" } }
+    patch rosetta.translation_key_translation_path(key), params: { locale_id: locale.id, translation_key: { value_fr: "Langues disponibles" } }
 
     # Deploy the changes
     post rosetta.locale_deploys_path(locale)

--- a/test/lib/rosetta/translated_test.rb
+++ b/test/lib/rosetta/translated_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+class Rosetta::TranslatedTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  test "setting a new translation" do
+    translation_key = rosetta_translation_keys(:goodbye)
+    translation_key.update(value_fr: "au revoir")
+    translation_key.reload
+
+    assert_equal "au revoir", translation_key.value_fr
+    assert_not_nil translation_key.fr_translation
+  end
+
+  test "setting a translation to blank removes the translation" do
+    translation_key = rosetta_translation_keys(:hello)
+
+    translation_key.update(value_fr: "")
+    translation_key.reload
+
+    assert_nil translation_key.value_fr
+    assert_nil translation_key.fr_translation
+  end
+
+  test "setting a translation without saving returns the updated translation" do
+    translation_key = rosetta_translation_keys(:hello)
+    translation_key.value_fr = "salut"
+
+    assert_equal "salut", translation_key.value_fr
+    assert_equal "bonjour", translation_key.reload.value_fr
+  end
+end

--- a/test/models/rosetta/locale_test.rb
+++ b/test/models/rosetta/locale_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "minitest/mock"
 
 class Rosetta::LocaleTest < ActiveSupport::TestCase
   test "valid locale" do
@@ -47,5 +48,15 @@ class Rosetta::LocaleTest < ActiveSupport::TestCase
     assert_equal "English", default_locale.name
     assert_equal "en", default_locale.code
     assert default_locale.default?
+  end
+
+  test "creating a new locale notifies translated models" do
+    translated_model = Minitest::Mock.new
+    translated_model.expect(:translated_in, nil, [ Rosetta::Locale ])
+
+    Rosetta::Locale.register_class_for_translation(translated_model)
+    Rosetta::Locale.create(name: "Italian", code: "it")
+
+    assert translated_model.verify
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -24,10 +24,12 @@ end
 class ActiveSupport::TestCase
   # Provide a clean slate for each test:
   # - Unset the default locale
+  # - Reset the registered classes for translations
   # - Reload all locale stores
   # - Set the locale to the default locale
   setup do
     Rosetta::Locale.default_locale = nil
+    Rosetta::Locale.registered_classes_for_translations = []
     Rosetta::Store.locale_stores.each { |code, store| store.reload! }
     Rosetta.locale = :en
   end


### PR DESCRIPTION
Closes #3 

In this PR we move away from using the `Rosetta.locale` global to scope translations for a given key to a given locale. 

The design and its pros and cons were previously explained in #3. 

While working on #10, it became clear that we needed dedicated getters and setters for scoped translations. Things like: 

```ruby
translation_key = Rosetta::TranslationKey.create(value: "hello") 
translation_key.update(value_fr: "bonjour") 
translation_key.fr_translation # => Rosetta::Translation(value: "bonjour")
```

A new `Translated` module is introduced, heavily inspired by what's been implemented in ActiveStorage in Rails itself. The main advantage of this design is that we can defer the setup of the `has_one` association when the parent model is saved. 

Additionnal logic can be implemented in `Rosetta::Translated::Create` and `Rosetta::Translated::Delete` to account for future needs and design evolution. 

Finally, the main blocker for implementing this was that we know available locales only at runtime. This is fine for existing locales, but new locales would not be associated to the TranslationKey model. 

This is fixed by adding a listener to the after a new locale is created. Translated model are notified of the newly created locale and appropriate associations are setup. 

https://github.com/virolea/rosetta/blob/dc0efb091088ddf0cc15486f5cf4151d1baf930c/app/models/rosetta/locale.rb#L36-L38

Note: the corollary is that locale codes can't be updated after the locale is created.